### PR TITLE
yt-dlp 실패 케이스 처리 및 더 구체적인 API 오류 응답 추가

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 import os
 import yt_dlp
 import urllib.parse
+import logging
 from flask import (Flask, render_template, request, send_file, 
                    jsonify, session, redirect, url_for)
 
@@ -8,6 +9,7 @@ from werkzeug.middleware.proxy_fix import ProxyFix
 
 # Flask 애플리케이션을 생성합니다.
 app = Flask(__name__)
+logger = logging.getLogger(__name__)
 
 app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1, x_prefix=1)
 
@@ -76,9 +78,9 @@ def download():
         return jsonify({'error': 'URL이 제공되지 않았습니다.'}), 400
 
     try:
+        cookiefile = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'cookies.txt')
         ydl_opts = {
             'format': 'bestaudio/best',
-	    'cookiefile': os.path.join(os.path.dirname(os.path.abspath(__file__)), 'cookies.txt'),
             'postprocessors': [{
                 'key': 'FFmpegExtractAudio',
                 'preferredcodec': 'mp3',
@@ -86,7 +88,15 @@ def download():
             }],
             'outtmpl': os.path.join(TEMP_DIR, '%(title)s.%(ext)s'),
             'restrictfilenames': True,
+            'extractor_args': {
+                'youtube': {
+                    'player_client': ['android', 'web', 'tv']
+                }
+            },
         }
+
+        if os.path.exists(cookiefile):
+            ydl_opts['cookiefile'] = cookiefile
 
         with yt_dlp.YoutubeDL(ydl_opts) as ydl:
             info_dict = ydl.extract_info(url, download=True)
@@ -118,7 +128,21 @@ def download():
         else:
             return jsonify({'error': 'MP3 파일을 생성하지 못했습니다.'}), 500
 
-    except Exception as e:
+    except yt_dlp.utils.DownloadError as e:
+        error_message = str(e)
+        logger.exception('yt-dlp download error: %s', error_message)
+
+        if 'n challenge solving failed' in error_message or 'Requested format is not available' in error_message:
+            return jsonify({
+                'error': (
+                    '유튜브 측 봇 방어로 인해 현재 서버에서 스트림 해석에 실패했습니다. '
+                    '서버의 yt-dlp를 최신 버전으로 업데이트하고 Node.js(또는 QuickJS) 런타임을 설치한 뒤 다시 시도해주세요.'
+                )
+            }), 503
+
+        return jsonify({'error': '영상 정보를 가져오지 못했습니다. 잠시 후 다시 시도해주세요.'}), 502
+    except Exception:
+        logger.exception('unexpected conversion error')
         return jsonify({'error': f'변환 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요'}), 500
 
 


### PR DESCRIPTION
### Motivation
- 운영 로그에서 `n challenge solving failed`와 `Requested format is not available` 에러로 오디오 포맷을 못 가져와 500 응답이 반환되는 문제가 반복되어 원인 파악 및 사용자 안내가 필요했습니다.
- yt-dlp가 쿠키 파일이 없거나 플레이어 클라이언트 옵션으로 인해 적절한 스트림을 선택하지 못하는 상황을 완화할 필요가 있었습니다.
- 개발/운영자가 문제 원인을 빠르게 진단할 수 있도록 로깅과 명확한 HTTP 상태 코드로 구분하려고 했습니다.

### Description
- `logging`을 도입해 `logger.exception`으로 yt-dlp 관련 에러와 예상치 못한 변환 에러를 기록하도록 했습니다 (추가: `logger` 생성).
- `cookies.txt`를 항상 넘기지 않도록 `cookiefile` 경로를 계산한 뒤 `os.path.exists`로 존재할 때만 `ydl_opts['cookiefile']`에 설정하도록 변경했습니다.
- 유튜브 추출기 옵션에 `extractor_args`를 추가해 `player_client`에 `['android','web','tv']`를 넣어 플레이어 클라이언트 폴백을 시도하도록 했습니다.
- `except yt_dlp.utils.DownloadError`를 별도로 처리해 에러 메시지에 따라 클라이언트에게 구체적인 안내를 담은 JSON과 적절한 상태 코드(`503` 또는 `502`)를 반환하도록 했고, 그 외 예외는 로깅 후 `500`을 유지합니다.

### Testing
- 자동 문법 검사인 `python -m py_compile app.py`을 실행해 컴파일 검사에 `OK`로 통과했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991c502c25c83329723a880b30a79e7)