### PR TITLE
Add clean NSIS installer releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,7 +117,7 @@ jobs:
             }
           }
 
-      - name: Package and checksum
+      - name: Package portable ZIP
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
@@ -128,6 +128,44 @@ jobs:
           $hash = (Get-FileHash -Algorithm SHA256 -LiteralPath $zip).Hash.ToLowerInvariant()
           "$hash  $zip" | Set-Content -LiteralPath "$zip.sha256" -Encoding ascii
 
+      - name: Install NSIS
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          choco install nsis -y --no-progress
+
+          $candidates = @(
+            "$env:ProgramFiles\NSIS\makensis.exe",
+            "${env:ProgramFiles(x86)}\NSIS\makensis.exe"
+          )
+          $makensis = $candidates | Where-Object { $_ -and (Test-Path -LiteralPath $_) } | Select-Object -First 1
+          if (-not $makensis) {
+            $command = Get-Command makensis.exe -ErrorAction SilentlyContinue
+            if ($command) { $makensis = $command.Source }
+          }
+          if (-not $makensis) {
+            throw 'makensis.exe was not found after installing NSIS.'
+          }
+
+          "MAKENSIS=$makensis" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Build installer
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $publishDir = (Resolve-Path 'publish').Path
+          & $env:MAKENSIS `
+            "/DPRODUCT_VERSION=$env:RELEASE_VERSION" `
+            "/DPUBLISH_DIR=$publishDir" `
+            'installer.nsi'
+
+          if ($LASTEXITCODE -ne 0 -or -not (Test-Path -LiteralPath 'ytdown-setup.exe')) {
+            throw 'NSIS installer build failed.'
+          }
+
+          $hash = (Get-FileHash -Algorithm SHA256 -LiteralPath 'ytdown-setup.exe').Hash.ToLowerInvariant()
+          "$hash  ytdown-setup.exe" | Set-Content -LiteralPath 'ytdown-setup.exe.sha256' -Encoding ascii
+
       - name: Create or update GitHub Release
         shell: pwsh
         env:
@@ -135,17 +173,18 @@ jobs:
         run: |
           $ErrorActionPreference = 'Stop'
           $tag = $env:RELEASE_TAG
+          $assets = @(
+            'ytdown-setup.exe',
+            'ytdown-setup.exe.sha256',
+            'ytdown-win-x64.zip',
+            'ytdown-win-x64.zip.sha256'
+          )
 
           if (gh release view $tag 2>$null) {
-            gh release upload $tag `
-              'ytdown-win-x64.zip' `
-              'ytdown-win-x64.zip.sha256' `
-              --clobber
+            gh release upload $tag @assets --clobber
           }
           else {
-            gh release create $tag `
-              'ytdown-win-x64.zip' `
-              'ytdown-win-x64.zip.sha256' `
+            gh release create $tag @assets `
               --title "ytdown $tag" `
               --generate-notes `
               --target '${{ github.sha }}'

--- a/installer.nsi
+++ b/installer.nsi
@@ -1,0 +1,128 @@
+Unicode true
+
+!ifndef PRODUCT_VERSION
+  !define PRODUCT_VERSION "0.0.0"
+!endif
+
+!ifndef PUBLISH_DIR
+  !define PUBLISH_DIR "publish"
+!endif
+
+!define PRODUCT_NAME "ytdown"
+!define PRODUCT_PUBLISHER "guite95"
+!define PRODUCT_WEB_SITE "https://github.com/guite95/youtube"
+!define PRODUCT_EXE "ytdown.exe"
+!define PRODUCT_UNINST_KEY "Software\Microsoft\Windows\CurrentVersion\Uninstall\ytdown"
+!define PRODUCT_APP_PATH_KEY "Software\Microsoft\Windows\CurrentVersion\App Paths\ytdown.exe"
+
+RequestExecutionLevel user
+SetCompressor /SOLID lzma
+SetCompressorDictSize 64
+
+!include "MUI2.nsh"
+
+!define MUI_ABORTWARNING
+!define MUI_FINISHPAGE_RUN "$INSTDIR\${PRODUCT_EXE}"
+!define MUI_FINISHPAGE_RUN_TEXT "ytdown 실행"
+
+!insertmacro MUI_PAGE_WELCOME
+!insertmacro MUI_PAGE_DIRECTORY
+!insertmacro MUI_PAGE_INSTFILES
+!insertmacro MUI_PAGE_FINISH
+
+!insertmacro MUI_UNPAGE_CONFIRM
+!insertmacro MUI_UNPAGE_INSTFILES
+
+!insertmacro MUI_LANGUAGE "Korean"
+
+Name "${PRODUCT_NAME} ${PRODUCT_VERSION}"
+OutFile "ytdown-setup.exe"
+InstallDir "$LOCALAPPDATA\Programs\ytdown"
+InstallDirRegKey HKCU "${PRODUCT_APP_PATH_KEY}" ""
+ShowInstDetails show
+ShowUnInstDetails show
+
+Var BackupDir
+
+Function .onInit
+  SetShellVarContext current
+FunctionEnd
+
+Function un.onInit
+  SetShellVarContext current
+FunctionEnd
+
+Section "ytdown" SEC_MAIN
+  SectionIn RO
+
+  ; 설치/업데이트 중 실행 중인 기존 프로세스의 파일 잠금을 해제합니다.
+  nsExec::ExecToStack '"$SYSDIR\taskkill.exe" /IM "${PRODUCT_EXE}" /T /F'
+  Pop $0
+  Pop $1
+
+  ; 사용자 데이터만 임시 보관합니다. 나머지 설치 파일은 전부 교체됩니다.
+  StrCpy $BackupDir "$TEMP\ytdown-install-backup"
+  RMDir /r "$BackupDir"
+  CreateDirectory "$BackupDir"
+
+  IfFileExists "$INSTDIR\cookies.txt" 0 +2
+    CopyFiles /SILENT "$INSTDIR\cookies.txt" "$BackupDir\cookies.txt"
+
+  IfFileExists "$INSTDIR\settings.json" 0 +2
+    CopyFiles /SILENT "$INSTDIR\settings.json" "$BackupDir\settings.json"
+
+  ; 구버전 DLL/tools/실행 파일이 남지 않도록 설치 폴더를 통째로 지웁니다.
+  RMDir /r "$INSTDIR"
+  CreateDirectory "$INSTDIR"
+  SetOutPath "$INSTDIR"
+
+  ; publish 디렉터리 전체를 새 설치 세트로 배치합니다.
+  File /r "${PUBLISH_DIR}\*.*"
+
+  ; 보존 대상으로 지정한 사용자 데이터만 복원합니다.
+  IfFileExists "$BackupDir\cookies.txt" 0 +2
+    CopyFiles /SILENT "$BackupDir\cookies.txt" "$INSTDIR\cookies.txt"
+
+  IfFileExists "$BackupDir\settings.json" 0 +2
+    CopyFiles /SILENT "$BackupDir\settings.json" "$INSTDIR\settings.json"
+
+  RMDir /r "$BackupDir"
+
+  WriteUninstaller "$INSTDIR\uninstall.exe"
+
+  CreateDirectory "$SMPROGRAMS\ytdown"
+  CreateShortCut "$SMPROGRAMS\ytdown\ytdown.lnk" "$INSTDIR\${PRODUCT_EXE}" "" "$INSTDIR\${PRODUCT_EXE}"
+  CreateShortCut "$SMPROGRAMS\ytdown\ytdown 제거.lnk" "$INSTDIR\uninstall.exe"
+  CreateShortCut "$DESKTOP\ytdown.lnk" "$INSTDIR\${PRODUCT_EXE}" "" "$INSTDIR\${PRODUCT_EXE}"
+
+  WriteRegStr HKCU "${PRODUCT_APP_PATH_KEY}" "" "$INSTDIR\${PRODUCT_EXE}"
+  WriteRegStr HKCU "${PRODUCT_APP_PATH_KEY}" "Path" "$INSTDIR"
+
+  WriteRegStr HKCU "${PRODUCT_UNINST_KEY}" "DisplayName" "${PRODUCT_NAME}"
+  WriteRegStr HKCU "${PRODUCT_UNINST_KEY}" "DisplayVersion" "${PRODUCT_VERSION}"
+  WriteRegStr HKCU "${PRODUCT_UNINST_KEY}" "DisplayIcon" "$INSTDIR\${PRODUCT_EXE}"
+  WriteRegStr HKCU "${PRODUCT_UNINST_KEY}" "Publisher" "${PRODUCT_PUBLISHER}"
+  WriteRegStr HKCU "${PRODUCT_UNINST_KEY}" "URLInfoAbout" "${PRODUCT_WEB_SITE}"
+  WriteRegStr HKCU "${PRODUCT_UNINST_KEY}" "InstallLocation" "$INSTDIR"
+  WriteRegStr HKCU "${PRODUCT_UNINST_KEY}" "UninstallString" '"$INSTDIR\uninstall.exe"'
+  WriteRegStr HKCU "${PRODUCT_UNINST_KEY}" "QuietUninstallString" '"$INSTDIR\uninstall.exe" /S'
+  WriteRegDWORD HKCU "${PRODUCT_UNINST_KEY}" "NoModify" 1
+  WriteRegDWORD HKCU "${PRODUCT_UNINST_KEY}" "NoRepair" 1
+SectionEnd
+
+Section "Uninstall"
+  nsExec::ExecToStack '"$SYSDIR\taskkill.exe" /IM "${PRODUCT_EXE}" /T /F'
+  Pop $0
+  Pop $1
+
+  Delete "$DESKTOP\ytdown.lnk"
+  Delete "$SMPROGRAMS\ytdown\ytdown.lnk"
+  Delete "$SMPROGRAMS\ytdown\ytdown 제거.lnk"
+  RMDir "$SMPROGRAMS\ytdown"
+
+  DeleteRegKey HKCU "${PRODUCT_UNINST_KEY}"
+  DeleteRegKey HKCU "${PRODUCT_APP_PATH_KEY}"
+
+  ; 제거 시에는 설치 폴더 전체를 삭제합니다.
+  RMDir /r "$INSTDIR"
+SectionEnd


### PR DESCRIPTION
## 변경 내용
- 사용자별 `%LOCALAPPDATA%\Programs\ytdown` 설치 방식의 NSIS 설치 프로그램 추가
- 설치/업그레이드 시 실행 중인 ytdown 종료 후 기존 설치 폴더 전체 제거
- `cookies.txt`, `settings.json`만 임시 백업 후 복원하여 구버전 DLL/tools 잔존 방지
- 시작 메뉴/바탕화면 바로가기와 Windows 제거 항목 등록
- Release workflow에서 `ytdown-setup.exe`와 SHA-256을 portable ZIP과 함께 자동 생성/업로드

`v2.0.1` 릴리스 빌드로 실제 NSIS 컴파일과 패키징을 검증할 예정입니다.